### PR TITLE
Add select all datasets and fix categoryOptionCombos

### DIFF
--- a/assets/stylesheets/app.css
+++ b/assets/stylesheets/app.css
@@ -1,6 +1,6 @@
 body {
 	margin: 3%;
-	height: 70%;
+	padding-bottom: 1em;
 }
 
 .greyfield,

--- a/index.html
+++ b/index.html
@@ -47,17 +47,24 @@
 				<input type="checkbox" ng-model="includeHeaders" aria-labelledby="includeHeaders">
 			</div>
 
-			<!-- INCLUDE HEADERS -->
+			<!-- SELECT ALL -->
 			<div class="row select-all">
-				<label id="selectAllLangs">{{ 'SELECT_ALL_LANGUAGES' | translate }}</label>
-				<input type="checkbox" ng-click="updateLangs()" ng-model="selectAllLangs"
-					aria-labelledby="selectAllLangs">
+				<div>
+					<label id="selectAllLangs">{{ 'SELECT_ALL_LANGUAGES' | translate }}</label>
+					<input type="checkbox" ng-click="updateLangs()" ng-model="selectAllLangs"
+						aria-labelledby="selectAllLangs">
+				</div>
+				<div>
+					<label id="selectAllDatasets">{{ 'SELECT_ALL_DATASETS' | translate }}</label>
+					<input type="checkbox" ng-click="updateDatasets()" ng-model="selectAllDatasets"
+						aria-labelledby="selectAllDatasets">
+				</div>
 			</div>
 
 			<!-- SELECTORS -->
-			<div class="row flex">
+			<div class="row flex" ng-hide="selectAllDatasets">
 				<div>
-					<form id="datasetSelectorForm" class="inline">
+					<form id="datasetSelectorForm" class="inline" ng-show="!selectAllDatasets">
 						<select title="Nothing selected" name="dataset" class="selectpicker hidden-print"
 							data-live-search="true" multiple>
 							<option disabled value="0">{{ 'SELECT_DATASET' | translate }}</option>

--- a/index.html
+++ b/index.html
@@ -35,6 +35,9 @@
 				<button type="button" id="export-button" ng-click="exportToTable('tallysheetForm')"
 					class="btn btn-success hidden-print" export-button="{{selectedDatasets}}">
 					{{ 'EXPORT_EXCEL' | translate}}</button>
+				<span ng-show="exporting" class="loading-icon">
+					<span class="glyphicon glyphicon-hourglass"></span>
+				</span>
 				<button id="homeBtn" ng-click="goHome()" class="btn btn-danger hidden-print">
 					<span class="glyphicon glyphicon-home"></span>
 					{{ 'HOME' | translate}}
@@ -56,13 +59,12 @@
 				</div>
 				<div>
 					<label id="selectAllDatasets">{{ 'SELECT_ALL_DATASETS' | translate }}</label>
-					<input type="checkbox" ng-click="updateDatasets()" ng-model="selectAllDatasets"
-						aria-labelledby="selectAllDatasets">
+					<input type="checkbox" ng-model="selectAllDatasets" aria-labelledby="selectAllDatasets">
 				</div>
 			</div>
 
 			<!-- SELECTORS -->
-			<div class="row flex" ng-hide="selectAllDatasets">
+			<div class="row flex" ng-hide="selectAllDatasets && selectAllLangs">
 				<div>
 					<form id="datasetSelectorForm" class="inline" ng-show="!selectAllDatasets">
 						<select title="Nothing selected" name="dataset" class="selectpicker hidden-print"

--- a/index.html
+++ b/index.html
@@ -33,7 +33,8 @@
 			<div class="row">
 				<button onclick="window.print()" class="btn btn-primary hidden-print">{{ 'PRINT' | translate }}</button>
 				<button type="button" id="export-button" ng-click="exportToTable('tallysheetForm')"
-					class="btn btn-success hidden-print" export-button="{{selectedDatasets}}">
+					class="btn btn-success hidden-print" export-button="{{selectedDatasets}}"
+					ng-disabled="progressbarDisplayed">
 					{{ 'EXPORT_EXCEL' | translate}}</button>
 				<span ng-show="exporting" class="loading-icon">
 					<span class="glyphicon glyphicon-hourglass"></span>

--- a/languages/en.json
+++ b/languages/en.json
@@ -6,6 +6,7 @@
 	"SELECT_DATASET": "Select a dataset",
 	"SELECT_LANGUAGE": "Select a language",
 	"SELECT_ALL_LANGUAGES": "Select all languages",
+	"SELECT_ALL_DATASETS": "Select all datasets",
 	"ADD_FORM": "Add form",
 	"HEADERS": "Include headers",
 	"FACILITY": "Health facility",

--- a/src/domain/usecases/ExportDatasetsUseCase.js
+++ b/src/domain/usecases/ExportDatasetsUseCase.js
@@ -136,12 +136,17 @@ function mapSection(section) {
 			categoryOptions.map(({ displayFormName }) => displayFormName)
 		);
 
+		const categoriesOrder = categoryCombo.categories.map(
+			({ categoryOptions }) => categoryOptions.map(({ id }) => id)
+		);
+
 		const categoryOptionCombos = categoryCombo.categoryOptionCombos
 			.map((categoryOptionCombo) => ({
 				...categoryOptionCombo,
-				categories: categoryOptionCombo.categoryOptions.flatMap(
-					({ displayFormName }) => displayFormName
-				),
+				categories: _.sortBy(
+					categoryOptionCombo.categoryOptions,
+					({ id }) => categoriesOrder.findIndex((c) => c.includes(id))
+				).map(({ displayFormName }) => displayFormName),
 			}))
 			.filter((categoryOptionCombo) => {
 				const flatCategories = categories.flat();


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/3qv7nad

### :memo: Implementation

Add a "select all datasets" checkbox, that automatically loads all the datasets forms and removes the dataset select. Languages continue behaving like before except that when "select all datasets" turns unchecked the language selector will clean the selected languages because no dataset is selected.

Also fix the trouble we had on the export showing the category option combos switched with each other.

### :art: Screenshots

![image](https://user-images.githubusercontent.com/43061485/218721384-b0333297-aeba-47f3-9eb4-316d0df9b101.png)