### PR TITLE
Translations adjustments

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,7 +79,8 @@
                             data-live-search="true" multiple>
                             <option disabled value="0">{{ 'SELECT_LANGUAGE' | translate }}</option>
                             <option ng-repeat="language in availableLanguages | orderBy : 'locale'"
-                                ng-value="language.locale" on-finish-render="ngRepeatFinished">{{ language.name }}
+                                ng-value="language.locale" on-finish-render="ngRepeatFinished"
+                                ng-selected="preferredLanguage==language.locale">{{ language.name }}
                             </option>
                         </select>
                     </form>

--- a/index.html
+++ b/index.html
@@ -32,8 +32,8 @@
             <div class="row">
                 <button onclick="window.print()" class="btn btn-primary hidden-print">{{ 'PRINT' | translate }}</button>
                 <button type="button" id="export-button" ng-click="exportToTable('tallysheetForm')"
-                    class="btn btn-success hidden-print" export-button="{{selectedDatasets}}"
-                    ng-disabled="progressbarDisplayed">
+                    class="btn btn-success hidden-print"
+                    export-button="{{ {selectedDatasets: selectedDatasets, selectedLocales: selectedLocales, progressbarDisplayed: progressbarDisplayed} }}">
                     {{ 'EXPORT_EXCEL' | translate}}</button>
                 <span ng-show="exporting" class="loading-icon">
                     <span class="glyphicon glyphicon-hourglass"></span>
@@ -47,7 +47,8 @@
             <!-- INCLUDE HEADERS -->
             <div class="row include-headers">
                 <label id="includeHeaders">{{ 'HEADERS' | translate }}</label>
-                <input type="checkbox" ng-model="includeHeaders" aria-labelledby="includeHeaders">
+                <input type="checkbox" ng-model="includeHeaders" aria-labelledby="includeHeaders"
+                    ng-disabled="exporting || progressbarDisplayed">
             </div>
 
             <!-- SELECT ALL -->
@@ -55,11 +56,12 @@
                 <div>
                     <label id="selectAllLangs">{{ 'SELECT_ALL_LANGUAGES' | translate }}</label>
                     <input type="checkbox" ng-click="updateLangs()" ng-model="selectAllLangs"
-                        aria-labelledby="selectAllLangs">
+                        aria-labelledby="selectAllLangs" ng-disabled="exporting || progressbarDisplayed">
                 </div>
                 <div>
                     <label id="selectAllDatasets">{{ 'SELECT_ALL_DATASETS' | translate }}</label>
-                    <input type="checkbox" ng-model="selectAllDatasets" aria-labelledby="selectAllDatasets">
+                    <input type="checkbox" ng-model="selectAllDatasets" aria-labelledby="selectAllDatasets"
+                        ng-disabled="progressbarDisplayed || exporting">
                 </div>
             </div>
 
@@ -68,7 +70,8 @@
                 <div>
                     <form id="datasetSelectorForm" class="inline" ng-show="!selectAllDatasets">
                         <select title="Nothing selected" name="dataset" class="selectpicker hidden-print"
-                            data-live-search="true" multiple>
+                            data-live-search="true" multiple ng-disabled="exporting || progressbarDisplayed"
+                            ng-class="(exporting || progressbarDisplayed) ? 'disabled' : ''">
                             <option disabled value="0">{{ 'SELECT_DATASET' | translate }}</option>
                             <option ng-repeat="dataset in datasets | orderBy : 'displayName'" ng-value="dataset.id"
                                 on-finish-render="ngRepeatFinished">{{dataset.displayName}}</option>
@@ -76,16 +79,19 @@
                     </form>
                     <form id="languageSelectorForm" class="inline" ng-show="!selectAllLangs">
                         <select title="Nothing selected" name="language" class="selectpicker hidden-print"
-                            data-live-search="true" multiple>
+                            data-live-search="true" multiple ng-disabled="exporting || progressbarDisplayed"
+                            ng-class="(exporting || progressbarDisplayed) ? 'disabled' : ''">
                             <option disabled value="0">{{ 'SELECT_LANGUAGE' | translate }}</option>
                             <option ng-repeat="language in availableLanguages | orderBy : 'locale'"
                                 ng-value="language.locale" on-finish-render="ngRepeatFinished"
-                                ng-selected="preferredLanguage==language.locale">{{ language.name }}
-                            </option>
+                                ng-selected="preferredLanguage===language.locale&&selectedDatasets.length>0">
+                                {{language.name}}</option>
                         </select>
                     </form>
                 </div>
-                <button ng-click="clearForm()" class="btn btn-default hidden-print">
+                <button ng-click="clearForm()" class="btn btn-default hidden-print"
+                    ng-class="(exporting || progressbarDisplayed) ? 'disabled' : ''"
+                    ng-disable="exporting || progressbarDisplayed">
                     <span class="glyphicon glyphicon-remove"></span>
                 </button>
                 <div>

--- a/languages/es.json
+++ b/languages/es.json
@@ -5,6 +5,8 @@
     "HOME": "Inicio",
     "SELECT_DATASET": "Selecciona un set de datos",
     "SELECT_LANGUAGE": "Selecciona un idioma",
+    "SELECT_ALL_LANGUAGES": "Seleccionar todos los idiomas",
+    "SELECT_ALL_DATASETS": "Seleccionar todos los sets de datos",
     "ADD_FORM": "Añadir formulario",
     "HEADERS": "Incluir cabeceras",
     "FACILITY": "Centro sanitario",

--- a/languages/fr.json
+++ b/languages/fr.json
@@ -5,6 +5,8 @@
     "HOME": "Accueil",
     "SELECT_DATASET": "Sélectionnez un ensemble de données",
     "SELECT_LANGUAGE": "Sélectionnez une langue",
+    "SELECT_ALL_LANGUAGES": "Sélectionnez toutes les langues",
+    "SELECT_ALL_DATASETS": "Sélectionner tous les ensembles de données",
     "ADD_FORM": "Ajouter formulaire",
     "HEADERS": "Ajouter en-tête",
     "FACILITY": "Structure de santé",

--- a/languages/pt.json
+++ b/languages/pt.json
@@ -5,6 +5,8 @@
     "HOME": "Principal",
     "SELECT_DATASET": "Selecione um conjunto de dados",
     "SELECT_LANGUAGE": "Selecione um idioma",
+    "SELECT_ALL_LANGUAGES": "Selecione todos os idiomas",
+    "SELECT_ALL_DATASETS": "Selecione todos os conjuntos de dados",
     "ADD_FORM": "Adicionar forma",
     "HEADERS": "Adicionar cabeçalho",
     "FACILITY": "Centro sanitário",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.1.0",
+    "version": "2.2.0",
     "name": "hmis-tally-sheets",
     "description": "HMIS Tally sheets",
     "author": "MSF OCBA, EyeSeeTea team",

--- a/src/data/repositories/DataSetsDhis2Repository.js
+++ b/src/data/repositories/DataSetsDhis2Repository.js
@@ -30,6 +30,7 @@ const fields = `
 	sections[
 		id,
 		translations,
+		name,
 		displayName,
 		description,
 		categoryCombos[

--- a/src/data/repositories/DataSetsDhis2Repository.js
+++ b/src/data/repositories/DataSetsDhis2Repository.js
@@ -23,6 +23,7 @@ const common = "id,name,displayFormName,translations";
 
 const fields = `
 	${common},
+	formName,
 	displayName,
 	formType,
 	sections[
@@ -41,8 +42,8 @@ const fields = `
 				categoryOptions[${common}]
 			]
 		],
-		dataElements[${common},categoryCombo],
+		dataElements[${common},formName,categoryCombo],
 		greyedFields[dataElement,categoryOptionCombo]
 	],
-	dataSetElements[categoryCombo[id,displayName,categories[*],categoryOptionCombos[*]],dataElement[${common}]],
+	dataSetElements[categoryCombo[id,displayName,categories[*],categoryOptionCombos[*]],dataElement[${common},formName]],
 `.replaceAll(/\s/g, "");

--- a/src/data/repositories/DataSetsDhis2Repository.js
+++ b/src/data/repositories/DataSetsDhis2Repository.js
@@ -19,14 +19,12 @@ export class DataSetsDhis2Repository {
     }
 }
 
-const common = "id,displayFormName,translations";
+const common = "id,name,displayFormName,translations";
 
 const fields = `
-	id,
-	name,
+	${common},
 	displayName,
 	formType,
-	displayFormName,
 	sections[
 		id,
 		translations,
@@ -38,6 +36,7 @@ const fields = `
 			categories[categoryOptions[${common}]],
 			categoryOptionCombos[
 				id,
+				name,
 				displayFormName,
 				categoryOptions[${common}]
 			]
@@ -46,5 +45,4 @@ const fields = `
 		greyedFields[dataElement,categoryOptionCombo]
 	],
 	dataSetElements[categoryCombo[id,displayName,categories[*],categoryOptionCombos[*]],dataElement[${common}]],
-	translations
 `.replaceAll(/\s/g, "");

--- a/src/data/repositories/DataSetsExportSpreadsheetRepository.js
+++ b/src/data/repositories/DataSetsExportSpreadsheetRepository.js
@@ -4,7 +4,7 @@ export class DataSetsExportSpreadsheetRepository {
             if (dataSet.formType === "SECTION" || dataSet.formType === "DEFAULT") {
                 return [
                     {
-                        name: `${dataSet.displayFormName.trim()}.xlsx`,
+                        name: `${dataSet.displayFormName.trim()}`,
                         blob: XlsxPopulate.fromBlankAsync().then(workbook => exportDataSet(workbook, dataSet)),
                     },
                 ];

--- a/src/data/repositories/DataSetsExportSpreadsheetRepository.js
+++ b/src/data/repositories/DataSetsExportSpreadsheetRepository.js
@@ -62,14 +62,15 @@ const styles = {
     },
 };
 
-function populateHeaders(sheet, header) {
+function populateHeaders(sheet, header, title) {
     sheet.cell("A1").value(header.healthFacility).style(styles.titleStyle);
     sheet.cell("A2").value(header.reportingPeriod).style({ bold: true, fontSize: 18 });
-    sheet.cell("A3").value(header.dataSetName).style(styles.titleStyle);
+    sheet.cell("A3").value(title).style(styles.titleStyle);
 }
 
 function populateDefault(sheet, dataSet) {
-    if (dataSet.headers) populateHeaders(sheet, dataSet.headers);
+    if (dataSet.headers)
+        populateHeaders(sheet, dataSet.headers, dataSet.displayFormName ?? dataSet.headers.dataSetName);
     sheet.cell("A4").value(dataSet.displayFormName).style(styles.titleStyle);
     sheet.cell("B6").value("Value");
     sheet.row(6).style(styles.categoryHeaderStyle);
@@ -88,7 +89,8 @@ function populateDefault(sheet, dataSet) {
 }
 
 function populateSections(sheet, dataSet) {
-    if (dataSet.headers) populateHeaders(sheet, dataSet.headers);
+    if (dataSet.headers)
+        populateHeaders(sheet, dataSet.headers, dataSet.displayFormName ?? dataSet.headers.dataSetName);
     let row = 3;
     _.range(0, dataSet.sections.length).forEach(i => {
         const section = dataSet.sections[i];

--- a/src/data/repositories/DataSetsExportSpreadsheetRepository.js
+++ b/src/data/repositories/DataSetsExportSpreadsheetRepository.js
@@ -4,9 +4,7 @@ export class DataSetsExportSpreadsheetRepository {
             if (dataSet.formType === "SECTION" || dataSet.formType === "DEFAULT") {
                 return [
                     {
-                        name: dataSet.pickedTranslations
-                            ? `${dataSet.name.trim()}_${dataSet.pickedTranslations}.xlsx`
-                            : `${dataSet.name.trim()}.xlsx`,
+                        name: `${dataSet.name.trim()}.xlsx`,
                         blob: XlsxPopulate.fromBlankAsync().then(workbook => exportDataSet(workbook, dataSet)),
                     },
                 ];
@@ -75,7 +73,7 @@ function populateDefault(sheet, dataSet) {
     sheet.cell("A4").value(dataSet.displayFormName).style(styles.titleStyle);
     sheet.cell("B6").value("Value");
     sheet.row(6).style(styles.categoryHeaderStyle);
-    _.sortBy(dataSet.dataSetElements, ({ displayFormName }) => displayFormName).forEach((de, idx) =>
+    dataSet.dataSetElements.forEach((de, idx) =>
         sheet
             .row(7 + idx) //(6 + 1 cause idx starts on 0)
             .cell(1)
@@ -136,7 +134,7 @@ function addSection(sheet, section, row) {
 
         const cocIds = categoryCombo.categoryOptionCombos.map(({ id }) => id);
 
-        _.sortBy(categoryCombo.dataElements, ({ displayFormName }) => displayFormName).forEach(de => {
+        categoryCombo.dataElements.forEach(de => {
             sheet.row(++row).cell(1).value(de.displayFormName).style(styles.dataElementStyle);
 
             if (!_.isEmpty(categoryCombo.greyedFields)) {

--- a/src/data/repositories/DataSetsExportSpreadsheetRepository.js
+++ b/src/data/repositories/DataSetsExportSpreadsheetRepository.js
@@ -4,7 +4,7 @@ export class DataSetsExportSpreadsheetRepository {
             if (dataSet.formType === "SECTION" || dataSet.formType === "DEFAULT") {
                 return [
                     {
-                        name: `${dataSet.name.trim()}.xlsx`,
+                        name: `${dataSet.displayFormName.trim()}.xlsx`,
                         blob: XlsxPopulate.fromBlankAsync().then(workbook => exportDataSet(workbook, dataSet)),
                     },
                 ];

--- a/src/domain/usecases/ExportDatasetsUseCase.js
+++ b/src/domain/usecases/ExportDatasetsUseCase.js
@@ -13,6 +13,7 @@ export class ExportDatasetsUseCase {
                     sections: dataSet.sections.filter(
                         section =>
                             !(
+                                section.name.toLowerCase().includes("comments") ||
                                 section.displayName.toLowerCase().includes("comments") ||
                                 section.displayName.toLowerCase().includes("comentarios") ||
                                 section.displayName.toLowerCase().includes("commentaires") ||

--- a/src/domain/usecases/ExportDatasetsUseCase.js
+++ b/src/domain/usecases/ExportDatasetsUseCase.js
@@ -254,7 +254,7 @@ function mapDataSetTranslations(dataSet) {
                     displayFormName:
                         getTranslationValue(de.translations, locale, "FORM_NAME") ??
                         getTranslationValue(de.translations, locale, "NAME") ??
-                        (locale === "en" ? de.formName : de.displayFormName),
+                        (locale === "en" ? de.formName ?? de.name : de.displayFormName),
                 })),
             })),
             dataSetElements: dataSet.dataSetElements.map(dse => ({
@@ -264,7 +264,9 @@ function mapDataSetTranslations(dataSet) {
                     displayFormName:
                         getTranslationValue(dse.dataElement.translations, locale, "FORM_NAME") ??
                         getTranslationValue(dse.dataElement.translations, locale, "NAME") ??
-                        (locale === "en" ? dse.dataElement.formName : dse.dataElement.displayFormName),
+                        (locale === "en"
+                            ? dse.dataElement.formName ?? dse.dataElement.name
+                            : dse.dataElement.displayFormName),
                 },
             })),
         };

--- a/src/domain/usecases/ExportDatasetsUseCase.js
+++ b/src/domain/usecases/ExportDatasetsUseCase.js
@@ -6,7 +6,7 @@ export class ExportDatasetsUseCase {
 
     execute($resource, dataSetsIds, _headers, locales, removedSections) {
         const translations$ = _.fromPairs(
-            locales.map(locale => [
+            _.uniq([...locales, "en"]).map(locale => [
                 locale,
                 fetch(`${location}/languages/${locale}.json`)
                     .then(response => response.json())
@@ -79,8 +79,9 @@ export class ExportDatasetsUseCase {
                 const mappedDatasets = getDataSets(translatedDatasets);
 
                 const dataSetsWithHeaders = mappedDatasets.map(dataSet => {
-                    const healthFacility = translations[dataSet.pickedTranslations]?.FACILITY;
-                    const reportingPeriod = translations[dataSet.pickedTranslations]?.PERIOD;
+                    const healthFacility =
+                        translations[dataSet.pickedTranslations]?.FACILITY ?? translations.en.FACILITY;
+                    const reportingPeriod = translations[dataSet.pickedTranslations]?.PERIOD ?? translations.en.PERIOD;
                     return {
                         ...dataSet,
                         headers: {

--- a/src/domain/usecases/ExportDatasetsUseCase.js
+++ b/src/domain/usecases/ExportDatasetsUseCase.js
@@ -213,7 +213,7 @@ function mapDataSetTranslations(dataSet) {
             ...dataSet,
             displayFormName:
                 getTranslationValue(dataSet.translations, locale) ??
-                (locale === "en" ? dataSet.name : dataSet.displayFormName),
+                (locale === "en" ? dataSet.formName ?? dataSet.name : dataSet.displayFormName),
             sections: dataSet.sections.map(section => ({
                 ...section,
                 //section does not have description available to translate??
@@ -254,7 +254,7 @@ function mapDataSetTranslations(dataSet) {
                     displayFormName:
                         getTranslationValue(de.translations, locale, "FORM_NAME") ??
                         getTranslationValue(de.translations, locale, "NAME") ??
-                        (locale === "en" ? de.name : de.displayFormName),
+                        (locale === "en" ? de.formName : de.displayFormName),
                 })),
             })),
             dataSetElements: dataSet.dataSetElements.map(dse => ({
@@ -264,7 +264,7 @@ function mapDataSetTranslations(dataSet) {
                     displayFormName:
                         getTranslationValue(dse.dataElement.translations, locale, "FORM_NAME") ??
                         getTranslationValue(dse.dataElement.translations, locale, "NAME") ??
-                        (locale === "en" ? dse.dataElement.name : dse.dataElement.displayFormName),
+                        (locale === "en" ? dse.dataElement.formName : dse.dataElement.displayFormName),
                 },
             })),
         };

--- a/src/domain/usecases/ExportDatasetsUseCase.js
+++ b/src/domain/usecases/ExportDatasetsUseCase.js
@@ -59,7 +59,7 @@ export class ExportDatasetsUseCase {
 
                 const translatedDatasets = pickedTranslations.flatMap(mapDataSetTranslations);
 
-                const mappedDatasets = getDataSets([...translatedDatasets, ...overridedDataSets]);
+                const mappedDatasets = getDataSets(_.isEmpty(locales) ? overridedDataSets : translatedDatasets);
 
                 const dataSetsWithHeaders = mappedDatasets.map(dataSet => ({
                     ...dataSet,
@@ -71,7 +71,13 @@ export class ExportDatasetsUseCase {
             .then(blobFiles => {
                 if (blobFiles.length > 1) {
                     const zip = new JSZip();
-                    blobFiles.forEach(file => zip.file(sanitizeFileName(file.name), file.blob));
+                    const names = [];
+                    blobFiles.forEach(file => {
+                        const name = sanitizeFileName(file.name);
+                        const idx = names.filter(s => s === name).length;
+                        zip.file(name + (idx ? ` (${idx})` : "") + ".xlsx", file.blob);
+                        names.push(name);
+                    });
 
                     return zip.generateAsync({ type: "blob" }).then(blob => {
                         saveAs(blob, "MSF-OCBA HMIS.zip");

--- a/src/domain/usecases/ExportDatasetsUseCase.js
+++ b/src/domain/usecases/ExportDatasetsUseCase.js
@@ -14,6 +14,10 @@ export class ExportDatasetsUseCase {
                         section =>
                             !(
                                 section.displayName.toLowerCase().includes("comments") ||
+                                section.displayName.toLowerCase().includes("comentarios") ||
+                                section.displayName.toLowerCase().includes("commentaires") ||
+                                section.displayName.toLowerCase().includes("comentários") ||
+                                section.displayName.toLowerCase().includes("notas") ||
                                 removedSections.includes(section.id)
                             )
                     ),

--- a/src/domain/usecases/ExportDatasetsUseCase.js
+++ b/src/domain/usecases/ExportDatasetsUseCase.js
@@ -59,7 +59,7 @@ export class ExportDatasetsUseCase {
 
                 const translatedDatasets = pickedTranslations.flatMap(mapDataSetTranslations);
 
-                const mappedDatasets = getDataSets(_.isEmpty(locales) ? overridedDataSets : translatedDatasets);
+                const mappedDatasets = getDataSets([...overridedDataSets, ...translatedDatasets]);
 
                 const dataSetsWithHeaders = mappedDatasets.map(dataSet => ({
                     ...dataSet,

--- a/src/domain/usecases/ExportDatasetsUseCase.js
+++ b/src/domain/usecases/ExportDatasetsUseCase.js
@@ -8,7 +8,7 @@ export class ExportDatasetsUseCase {
         const translations$ = _.fromPairs(
             locales.map(locale => [
                 locale,
-                fetch(`../../../languages/${locale}.json`)
+                fetch(`${location}/languages/${locale}.json`)
                     .then(response => response.json())
                     .catch(() => undefined),
             ])
@@ -299,3 +299,5 @@ function mapDataSetTranslations(dataSet) {
         return { ...mappedDataset, pickedTranslations: locale };
     });
 }
+
+const location = window.location.href.substring(0, window.location.href.lastIndexOf("/"));

--- a/src/views/formDatasetView.html
+++ b/src/views/formDatasetView.html
@@ -1,9 +1,9 @@
 <div class="dataset-form" ng-controller="formDatasetCtrl">
     <div ng-show="includeHeaders">
-        <h3><input type="text" class="dsTitle" ng-model="headers.healthFacility" /></h3>
-        <h3><input type="text" class="dsTitle" ng-model="headers.reportingPeriod" /></h3>
+        <h3><input type="text" class="dsTitle" ng-model="headers.healthFacility" readonly /></h3>
+        <h3><input type="text" class="dsTitle" ng-model="headers.reportingPeriod" readonly /></h3>
     </div>
-    <h2><input id="title" class="dsTitle" ng-model="headers.dataSetName" /></h2>
+    <h2><input id="title" class="dsTitle" ng-model="headers.dataSetName" readonly /></h2>
     <div id="dataset-{{ dataset.id }}">
         <ng-bind-html ng-bind-html="deliberatelyTrustDangerousSnippet()" on-finish-render></ng-bind-html>
     </div>

--- a/src/webapp/controllers/TallySheetsController.js
+++ b/src/webapp/controllers/TallySheetsController.js
@@ -158,15 +158,16 @@ export const TallySheetsController = TallySheets.controller("TallySheetsControll
                 ? $scope.datasets
                 : $scope.datasets.filter(dataset => selectedIds.includes(dataset.id));
 
-            const availableLocales = _.uniq(
-                selectedDatasets
+            const availableLocales = _.uniq([
+                ...selectedDatasets
                     .map(dataset =>
                         dataset.translations?.flatMap(translation =>
                             translation.property === "NAME" ? [translation.locale.split("_")[0]] : []
                         )
                     )
-                    .flat()
-            );
+                    .flat(),
+                "en",
+            ]);
 
             if ($scope.selectAllLangs) $scope.selectedLocales = availableLocales;
             else {

--- a/src/webapp/controllers/TallySheetsController.js
+++ b/src/webapp/controllers/TallySheetsController.js
@@ -2,13 +2,15 @@ import { TallySheets } from "../TallySheets.js";
 import { dhisUrl, compositionRoot } from "../app.js";
 
 export const TallySheetsController = TallySheets.controller("TallySheetsController", [
+    "$rootScope",
     "$scope",
     "$resource",
     "$timeout",
+    "$translate",
     "DataSetsUID",
     "Locales",
     "DataSetEntryForm",
-    function ($scope, $resource, $timeout, DataSetsUID, Locales, DataSetEntryForm) {
+    function ($rootScope, $scope, $resource, $timeout, $translate, DataSetsUID, Locales, DataSetEntryForm) {
         $scope.includeHeaders = true;
         $scope.datasets = [];
         $scope.selectedDatasets = [];
@@ -33,6 +35,11 @@ export const TallySheetsController = TallySheets.controller("TallySheetsControll
             );
 
             $scope.selectorsLoaded = true;
+        });
+
+        $rootScope.$on("$translateChangeSuccess", function () {
+            $scope.healthFacility = $translate.instant("FACILITY");
+            $scope.reportingPeriod = $translate.instant("PERIOD");
         });
 
         $scope.$on("ngRepeatFinished", function (ngRepeatFinishedEvent) {
@@ -176,8 +183,8 @@ export const TallySheetsController = TallySheets.controller("TallySheetsControll
                             dataset,
                             headers: {
                                 id: dataset.id,
-                                healthFacility: "Health Facility: ",
-                                reportingPeriod: "Reporting Period: ",
+                                healthFacility: `${$scope.healthFacility}: `,
+                                reportingPeriod: `${$scope.reportingPeriod}: `,
                                 dataSetName: dataset.displayName,
                             },
                             output: codeHtml,

--- a/src/webapp/directives/exportButtonDirective.js
+++ b/src/webapp/directives/exportButtonDirective.js
@@ -3,7 +3,10 @@ import { TallySheets } from "../TallySheets.js";
 export const exportButtonDirective = TallySheets.directive("exportButton", function () {
     return (scope, element, attrs) => {
         attrs.$observe("exportButton", value => {
-            if (_.isEmpty(JSON.parse(value))) _.first(element).disabled = true;
+            const v = JSON.parse(value);
+            const { selectedDatasets, selectedLocales, progressbarDisplayed } = v ?? {};
+            if (!selectedDatasets || !selectedLocales || progressbarDisplayed) _.first(element).disabled = true;
+            else if (_.isEmpty(selectedDatasets) || _.isEmpty(selectedLocales)) _.first(element).disabled = true;
             else _.first(element).disabled = false;
         });
     };

--- a/src/webapp/factories/UserSettingsKeyUiLocaleFactory.js
+++ b/src/webapp/factories/UserSettingsKeyUiLocaleFactory.js
@@ -1,0 +1,20 @@
+import { TallySheets } from "../TallySheets.js";
+import { apiUrl } from "../app.js";
+
+export const UserSettingsKeyUiLocaleFactory = TallySheets.factory("UserSettingsKeyUiLocale", [
+    "$resource",
+    function ($resource) {
+        return $resource(
+            apiUrl + "/userSettings/keyUiLocale/",
+            {},
+            {
+                get: {
+                    method: "GET",
+                    transformResponse: function (response) {
+                        return { response };
+                    },
+                },
+            }
+        );
+    },
+]);

--- a/src/webapp/factories/index.js
+++ b/src/webapp/factories/index.js
@@ -1,3 +1,4 @@
 import "./DataSetsUIDFactory.js";
 import "./DataSetEntryForm.js";
 import "./LocalesFactory.js";
+import "./UserSettingsKeyUiLocaleFactory.js";


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/3qv7nad

### :memo: Implementation

- Name of each file as the dataset name translation (if duplicates exist, they will be printed as _"(N)"_ at the end of the filename).
- Headers fields are now marked as `readonly` and are now retrieved by the UI translations and the dataset title is retrieved from the dataset name translation.
- Added `SELECT_ALL_LANGUAGES` and `SELECT_ALL_DATASETS` translations on **ES**, **PT**, and **FR**.
- Hide comments on excel
- Data elements are no longer sorted by default
- Added english as language, and mark as default the user's language

### :art: Screenshots

![image](https://user-images.githubusercontent.com/43061485/220630140-e95c85ae-9082-4ffc-83fe-3fefb34fb0f6.png)
![image](https://user-images.githubusercontent.com/43061485/220630295-b48b55cd-6906-4668-845c-a13bdb62cf80.png)
![image](https://user-images.githubusercontent.com/43061485/220630555-ab59865d-4585-4bb3-94e0-2e435856cf1d.png)