### PR TITLE
"Select ALL languages" option only visible to admin

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
 
             <!-- SELECT ALL -->
             <div class="row select-all">
-                <div>
+                <div ng-show="isAdmin">
                     <label id="selectAllLangs">{{ 'SELECT_ALL_LANGUAGES' | translate }}</label>
                     <input type="checkbox" ng-click="updateLangs()" ng-model="selectAllLangs"
                         aria-labelledby="selectAllLangs" ng-disabled="exporting || progressbarDisplayed">

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.3.0",
+    "version": "2.4.0",
     "name": "hmis-tally-sheets",
     "description": "HMIS Tally sheets",
     "author": "MSF OCBA, EyeSeeTea team",

--- a/src/webapp/factories/CurrentUserFactory.js
+++ b/src/webapp/factories/CurrentUserFactory.js
@@ -1,0 +1,21 @@
+import { TallySheets } from "../TallySheets.js";
+import { apiUrl } from "../app.js";
+
+export const CurrentUserFactory = TallySheets.factory("CurrentUser", [
+    "$resource",
+    function ($resource) {
+        return $resource(
+            apiUrl + "/me.json",
+            {},
+            {
+                get: {
+                    method: "GET",
+                    params: {
+                        fields: "id,userGroups",
+                        paging: false,
+                    },
+                },
+            }
+        );
+    },
+]);

--- a/src/webapp/factories/StorageFactory.js
+++ b/src/webapp/factories/StorageFactory.js
@@ -1,0 +1,22 @@
+import { TallySheets } from "../TallySheets.js";
+import { apiUrl } from "../app.js";
+
+export const StorageFactory = TallySheets.factory("Storage", [
+    "$resource",
+    function ($resource) {
+        return $resource(
+            apiUrl + "/constants.json",
+            {},
+            {
+                get: {
+                    method: "GET",
+                    params: {
+                        fields: "id,code,description",
+                        filter: "code:eq:TALLY_SHEETS_STORAGE",
+                        paging: false,
+                    },
+                },
+            }
+        );
+    },
+]);

--- a/src/webapp/factories/UserGroupsFactory.js
+++ b/src/webapp/factories/UserGroupsFactory.js
@@ -1,0 +1,21 @@
+import { TallySheets } from "../TallySheets.js";
+import { apiUrl } from "../app.js";
+
+export const UserGroupsFactory = TallySheets.factory("UserGroups", [
+    "$resource",
+    function ($resource) {
+        return $resource(
+            apiUrl + "/userGroups.json",
+            {},
+            {
+                get: {
+                    method: "GET",
+                    params: {
+                        fields: "id",
+                        paging: false,
+                    },
+                },
+            }
+        );
+    },
+]);

--- a/src/webapp/factories/index.js
+++ b/src/webapp/factories/index.js
@@ -1,4 +1,7 @@
 import "./DataSetsUIDFactory.js";
 import "./DataSetEntryForm.js";
 import "./LocalesFactory.js";
+import "./StorageFactory.js";
+import "./CurrentUserFactory.js";
+import "./UserGroupsFactory.js";
 import "./UserSettingsKeyUiLocaleFactory.js";


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/865cd7adg

### :memo: Implementation

Make "SELECT ALL LANGUAGES" option only available when the user belongs to Administrator's group. The group ID must be defined in the "Tally sheets storage" constant, along the `administratorGroups` key. If the group ID doesn't exist or is not defined, the option will be shown as requested.

### :fire: Testing

Import the metadata JSON file attached to the clickup task.