### PR TITLE
feat: add compile time storage source option

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,8 @@
 BROWSER=false
 VITE_PORT=8081
 
+# dataStore | constants
+VITE_STORAGE_SOURCE=dataStore
+
 VITE_DHIS2_BASE_URL=https://dev.eyeseetea.com/play
 VITE_DHIS2_AUTH='admin:district'

--- a/src/app-config.ts
+++ b/src/app-config.ts
@@ -21,4 +21,4 @@ interface AppConfig {
     storage: StorageSource;
 }
 
-export type StorageSource = typeof storageSources[number];
+export type StorageSource = (typeof storageSources)[number];

--- a/src/app-config.ts
+++ b/src/app-config.ts
@@ -9,7 +9,7 @@ export const appConfig: AppConfig = {
         showShareButton: false,
     },
     feedback: undefined,
-    storage: storageSources.includes(rawStorageSource) ? rawStorageSource : "constants",
+    storage: storageSources.includes(rawStorageSource) ? rawStorageSource : "dataStore",
 };
 
 interface AppConfig {

--- a/src/app-config.ts
+++ b/src/app-config.ts
@@ -1,12 +1,15 @@
 import { FeedbackOptions } from "@eyeseetea/feedback-component";
 
+const rawStorageSource = import.meta.env.VITE_STORAGE_SOURCE;
+
+export const storageSources = ["constants", "dataStore"] as const;
 export const appConfig: AppConfig = {
     id: "hmis-tally-sheets",
     appearance: {
         showShareButton: false,
     },
     feedback: undefined,
-    storage: "constants",
+    storage: storageSources.includes(rawStorageSource) ? rawStorageSource : "constants",
 };
 
 interface AppConfig {
@@ -15,7 +18,7 @@ interface AppConfig {
         showShareButton: boolean;
     };
     feedback?: FeedbackOptions;
-    storage: "constants" | "dataStore";
+    storage: StorageSource;
 }
 
-export type StorageSource = AppConfig["storage"];
+export type StorageSource = typeof storageSources[number];


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #8698zgw6m [Logic to compile as datastore and constant](https://app.clickup.com/t/8698zgw6m)

### :memo: Implementation
- add compile var storage source. Default is dataStore
```
# dataStore | constants
VITE_STORAGE_SOURCE=dataStore
```

### :video_camera: Screenshots/Screen capture

### :fire: Notes to the tester
